### PR TITLE
Add improved logging

### DIFF
--- a/automedia_jsonrpc/app/server.py
+++ b/automedia_jsonrpc/app/server.py
@@ -23,7 +23,7 @@ import logging
 import json
 import threading
 import time
-import os 
+import os
 from jsonrpc import JSONRPCResponseManager, dispatcher
 
 from werkzeug.wrappers import Request, Response
@@ -34,6 +34,18 @@ import core.face_processor
 import core.metadata_processor
 import core.text_processor
 # import core.yolo_processor
+
+# Grabbing environment variables
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
+
+logging.basicConfig(
+    level=LOG_LEVEL,
+    format="[%(levelname)s] Automedia @ %(asctime)s | %(message)s",
+    handlers=[
+        logging.FileHandler(f'/log/automedia.log'),
+        logging.StreamHandler()
+    ]
+)
 
 
 @dispatcher.add_method

--- a/config/dev/jsonrpc.env
+++ b/config/dev/jsonrpc.env
@@ -2,3 +2,5 @@ JSONRPC_USER=automedia
 # Set (at least) this to something random
 JSONRPC_PASS=automedia
 JSONRPC_THREADS=4
+# One of: DEBUG, INFO, WARNING, ERROR
+LOG_LEVEL=INFO

--- a/config/pro/jsonrpc.env.template
+++ b/config/pro/jsonrpc.env.template
@@ -2,3 +2,5 @@ JSONRPC_USER=automedia
 # Set (at least) this to something random
 JSONRPC_PASS=CHANGE_ME
 JSONRPC_THREADS=4
+# One of: DEBUG, INFO, WARNING, ERROR
+LOG_LEVEL=INFO


### PR DESCRIPTION
Logs are also saved now under `/log/`. The log level for the JSON RPC server is also configurable now from the environment file in `config/<ENVIRONMENT>/jsonrpc.env`.